### PR TITLE
Add bug fixes

### DIFF
--- a/DailyScreenshot/ModEntry.cs
+++ b/DailyScreenshot/ModEntry.cs
@@ -24,11 +24,20 @@ namespace DailyScreenshot
             {
                 exportDirectory = stardewValleyRootDirectory.CreateSubdirectory("MapExport");
             }
-
             CreateFileSystemWatcher();
-            screenshotsDirectory = exportDirectory.CreateSubdirectory("Screenshots");
-            helper.Events.Player.Warped += OnNewLocationEntered;
-            helper.Events.GameLoop.DayEnding += SetScreenshotTakenTodayToFalse;
+            helper.Events.GameLoop.SaveLoaded += OnSaveLoaded;
+        }
+
+        /// <summary>Raised after the save file is loaded.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event data.</param>
+        private void OnSaveLoaded(object sender, SaveLoadedEventArgs e)
+        {
+            var farmName = Game1.player.farmName;
+            var directoryName = $"{farmName}-Farm-Screenshots";
+            screenshotsDirectory = exportDirectory.CreateSubdirectory(directoryName);
+            Helper.Events.Player.Warped += OnNewLocationEntered;
+            Helper.Events.GameLoop.DayEnding += SetScreenshotTakenTodayToFalse;
         }
 
         /// <summary>Creates a new FileSystemWatcher and set its properties.</summary>

--- a/DailyScreenshot/manifest.json
+++ b/DailyScreenshot/manifest.json
@@ -2,7 +2,7 @@
   "Name": "Daily Screenshot",
   "Author": "CompSciLauren",
   "Version": "1.0.0",
-  "Description": "Automatically takes a screenshot of your entire farm at the start of each day.",
+  "Description": "Automatically takes a daily screenshot of your entire farm.",
   "UniqueID": "CompSciLauren.DailyScreenshot",
   "EntryDll": "DailyScreenshot.dll",
   "MinimumApiVersion": "2.10.0",

--- a/DailyScreenshot/manifest.json
+++ b/DailyScreenshot/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "Name": "Daily Screenshot",
   "Author": "CompSciLauren",
-  "Version": "1.0.0",
+  "Version": "1.0.1",
   "Description": "Automatically takes a daily screenshot of your entire farm.",
   "UniqueID": "CompSciLauren.DailyScreenshot",
   "EntryDll": "DailyScreenshot.dll",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Daily Screenshot - 1.0.0
+# Daily Screenshot - 1.0.1
 
 > A Stardew Valley mod that automatically takes a screenshot of your entire farm at the start of each day.
 
@@ -17,14 +17,14 @@ Each screenshot is named with "year-season-day.png" numerical format. So on Year
 
 ## Compatibility
 
-Works with Stardew Valley 1.4 on Linux/Mac/Windows.
+- Works with Stardew Valley 1.4 or later on Linux/Mac/Windows.
+- Works in both singleplayer and multiplayer.
+- No known mod conflicts.
 
 ## Known Issues
 
-- Has not been tested in multiplayer.
-  Has not been tested in Stardew Valley versions prior to 1.4.
-- Weather always appears clear in screenshots, even if it is not clear in-game (raining, snowing, etc). Only exception is that on days that do not have clear weather, part of the actual weather can be seen in the upper-left hand corner of the screenshot.
-- No configurations are available in the initial release of this mod. Configurations will be added in the next update.
+- Screenshots currently show all days as having "clear" weather (even if it is raining, snowing, etc). The only exception is that on days that do not actually have clear weather, part of the actual weather can be seen in the upper-left hand corner of the screenshot.
+- No configuration options are currently available in this mod. Configurations will be added in the next major update (v1.1.0). This will include, among other things, configurations for weather (e.g. choosing to allow rainy weather to appear in screenshots, or disabling all weather besides "clear" weather).
 
 ## License
 


### PR DESCRIPTION
- Added multiple screenshot folders, one per save file, so screenshots of different save files don't get mixed up.
- Shortened mod description in manifest file so it is more likely to appear on one line in the terminal when the game is launched.
- Bumped Map Image Export dependency version from 1.0.6 to 1.0.7.