### PR TITLE
Add bug fixes for patch 1.0.2

### DIFF
--- a/DailyScreenshot/ModEntry.cs
+++ b/DailyScreenshot/ModEntry.cs
@@ -32,6 +32,15 @@ namespace DailyScreenshot
             Helper.Events.Player.Warped += OnNewLocationEntered;
             Helper.Events.GameLoop.DayEnding += SetScreenshotTakenTodayToFalse;
             takeScreenshot = Helper.Reflection.GetMethod(Game1.game1, "takeMapScreenshot");
+            Helper.Events.GameLoop.ReturnedToTitle += OnReturnedToTitle;
+        }
+
+        /// <summary>Raised after the player returns to the title screen.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event data.</param>
+        private void OnReturnedToTitle(object sender, ReturnedToTitleEventArgs e)
+        {
+            screenshotTakenToday = false;
         }
 
         /// <summary>Raised after the player enters a new location.</summary>
@@ -100,6 +109,7 @@ namespace DailyScreenshot
         /// <param name="screenshotName">The name of the screenshot file.</param>
         private void MoveScreenshotToCorrectFolder(string screenshotName)
         {
+            // gather directory and file paths
             string screenshotNameWithExtension = screenshotName + ".png";
             string appDataDirectory = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
             string stardewValleyScreenshotsDirectory = Path.Combine(appDataDirectory, "StardewValley\\Screenshots");
@@ -109,14 +119,17 @@ namespace DailyScreenshot
             string saveDirectoryAndNewFile = Path.Combine(saveDirectory, screenshotNameWithExtension);
             string destinationFile = Path.Combine(stardewValleyScreenshotsDirectory, saveDirectoryAndNewFile);
 
-            // create folder if it doesn't exist
+            // create save directory if it doesn't exist
             if (!System.IO.File.Exists(saveDirectoryFullPath))
             {
                 System.IO.Directory.CreateDirectory(saveDirectoryFullPath);
             }
 
-            // To move a file or folder to a new location:
-            System.IO.File.Move(sourceFile, destinationFile);
+            // move screenshot into correct folder, overwrite file if already exists in folder
+            System.IO.File.Copy(sourceFile, destinationFile, true);
+
+            // delete original screenshot that still exists in StardewValley/Screenshots
+            System.IO.File.Delete(sourceFile);
         }
 
         /// <summary>Raised if the screenshot is changed.</summary>

--- a/DailyScreenshot/ModEntry.cs
+++ b/DailyScreenshot/ModEntry.cs
@@ -14,6 +14,7 @@ namespace DailyScreenshot
         private string stardewValleyLocation = "Farm";
         private string stardewValleyYear, stardewValleySeason, stardewValleyDayOfMonth;
         private bool screenshotTakenToday = false;
+        IReflectedMethod takeScreenshot = null;
 
         /// <summary>The mod entry point, called after the mod is first loaded.</summary>
         /// <param name="helper">Provides simplified APIs for writing mods.</param>
@@ -39,7 +40,10 @@ namespace DailyScreenshot
             screenshotsDirectory = exportDirectory.CreateSubdirectory(directoryName);
             Helper.Events.Player.Warped += OnNewLocationEntered;
             Helper.Events.GameLoop.DayEnding += SetScreenshotTakenTodayToFalse;
+            takeScreenshot = Helper.Reflection.GetMethod(Game1.game1, "takeMapScreenshot");
         }
+
+
 
         /// <summary>Creates a new FileSystemWatcher and set its properties.</summary>
         private void CreateFileSystemWatcher()
@@ -83,10 +87,41 @@ namespace DailyScreenshot
         private async void TakeScreenshot()
         {
             // wait 0.6 seconds so that buildings on map can completely render
-            await Task.Delay(600);
+            await Task.Delay(10000);
+
+            // prepare screenshot name
+            stardewValleyYear = Game1.Date.Year.ToString();
+            stardewValleySeason = Game1.Date.Season.ToString();
+            stardewValleyDayOfMonth = Game1.Date.DayOfMonth.ToString();
+
+            if (int.Parse(stardewValleyYear) < 10)
+            {
+                stardewValleyYear = "0" + stardewValleyYear;
+            }
+            if (int.Parse(stardewValleyDayOfMonth) < 10)
+            {
+                stardewValleyDayOfMonth = "0" + stardewValleyDayOfMonth;
+            }
+
+            switch (Game1.Date.Season)
+            {
+                case "spring":
+                    stardewValleySeason = "01";
+                    break;
+                case "summer":
+                    stardewValleySeason = "02";
+                    break;
+                case "fall":
+                    stardewValleySeason = "03";
+                    break;
+                case "winter":
+                    stardewValleySeason = "04";
+                    break;
+            }
 
             // take screenshot
-            Helper.ConsoleCommands.Trigger("export", new[] { stardewValleyLocation, "all" });
+            string screenshotName = $"{stardewValleyYear}-{stardewValleySeason}-{stardewValleyDayOfMonth}";
+            takeScreenshot.Invoke<string>(0.25f, screenshotName);
             screenshotTakenToday = true;
         }
 

--- a/DailyScreenshot/ModEntry.cs
+++ b/DailyScreenshot/ModEntry.cs
@@ -3,6 +3,7 @@ using StardewModdingAPI.Events;
 using StardewValley;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace DailyScreenshot
 {
@@ -74,9 +75,19 @@ namespace DailyScreenshot
         {
             if (e.NewLocation is Farm && !screenshotTakenToday)
             {
-                Helper.ConsoleCommands.Trigger("export", new[] { stardewValleyLocation, "all" });
-                screenshotTakenToday = true;
+                TakeScreenshot();
             }
+        }
+
+        /// <summary>Takes a screenshot of the entire farm.</summary>
+        private async void TakeScreenshot()
+        {
+            // wait 0.6 seconds so that buildings on map can completely render
+            await Task.Delay(600);
+
+            // take screenshot
+            Helper.ConsoleCommands.Trigger("export", new[] { stardewValleyLocation, "all" });
+            screenshotTakenToday = true;
         }
 
         /// <summary>Raised if the screenshot is changed.</summary>

--- a/DailyScreenshot/ModEntry.cs
+++ b/DailyScreenshot/ModEntry.cs
@@ -1,8 +1,8 @@
 ﻿using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewValley;
+using System;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace DailyScreenshot
@@ -10,7 +10,6 @@ namespace DailyScreenshot
     /// <summary>The mod entry point.</summary>
     public class ModEntry : Mod
     {
-        private DirectoryInfo exportDirectory, screenshotsDirectory;
         private string stardewValleyLocation = "Farm";
         private string stardewValleyYear, stardewValleySeason, stardewValleyDayOfMonth;
         private bool screenshotTakenToday = false;
@@ -20,13 +19,6 @@ namespace DailyScreenshot
         /// <param name="helper">Provides simplified APIs for writing mods.</param>
         public override void Entry(IModHelper helper)
         {
-            var stardewValleyRootDirectory = new DirectoryInfo(Constants.ExecutionPath);
-            exportDirectory = stardewValleyRootDirectory.EnumerateDirectories("MapExport").FirstOrDefault();
-            if (exportDirectory == null)
-            {
-                exportDirectory = stardewValleyRootDirectory.CreateSubdirectory("MapExport");
-            }
-            CreateFileSystemWatcher();
             helper.Events.GameLoop.SaveLoaded += OnSaveLoaded;
         }
 
@@ -37,39 +29,9 @@ namespace DailyScreenshot
         {
             var farmName = Game1.player.farmName;
             var directoryName = $"{farmName}-Farm-Screenshots";
-            screenshotsDirectory = exportDirectory.CreateSubdirectory(directoryName);
             Helper.Events.Player.Warped += OnNewLocationEntered;
             Helper.Events.GameLoop.DayEnding += SetScreenshotTakenTodayToFalse;
             takeScreenshot = Helper.Reflection.GetMethod(Game1.game1, "takeMapScreenshot");
-        }
-
-
-
-        /// <summary>Creates a new FileSystemWatcher and set its properties.</summary>
-        private void CreateFileSystemWatcher()
-        {
-            FileSystemWatcher watcher = new FileSystemWatcher
-            {
-
-                // Set watcher path.
-                Path = exportDirectory.FullName,
-
-                // Watch for changes in LastAccess and LastWrite times, and the renaming of files or directories.
-                NotifyFilter = NotifyFilters.LastAccess
-                                 | NotifyFilters.LastWrite
-                                 | NotifyFilters.FileName
-                                 | NotifyFilters.DirectoryName,
-
-                // Only watch Portable Network Graphics files.
-                Filter = $"*.png"
-            };
-
-            // Add event handlers.
-            watcher.Changed += OnScreenshotChanged;
-            watcher.Created += OnScreenshotChanged;
-
-            // Begin watching.
-            watcher.EnableRaisingEvents = true;
         }
 
         /// <summary>Raised after the player enters a new location.</summary>
@@ -87,9 +49,23 @@ namespace DailyScreenshot
         private async void TakeScreenshot()
         {
             // wait 0.6 seconds so that buildings on map can completely render
-            await Task.Delay(10000);
+            await Task.Delay(600);
 
             // prepare screenshot name
+            PrepareScreenshotName();
+
+            // take screenshot
+            string screenshotName = $"{stardewValleyYear}-{stardewValleySeason}-{stardewValleyDayOfMonth}";
+            takeScreenshot.Invoke<string>(0.25f, screenshotName);
+            screenshotTakenToday = true;
+
+            // move screenshot to correct folder
+            MoveScreenshotToCorrectFolder(screenshotName);
+        }
+
+        /// <summary>Fix the screenshot name to be in the proper format.</summary>
+        private void PrepareScreenshotName()
+        {
             stardewValleyYear = Game1.Date.Year.ToString();
             stardewValleySeason = Game1.Date.Season.ToString();
             stardewValleyDayOfMonth = Game1.Date.DayOfMonth.ToString();
@@ -118,11 +94,29 @@ namespace DailyScreenshot
                     stardewValleySeason = "04";
                     break;
             }
+        }
 
-            // take screenshot
-            string screenshotName = $"{stardewValleyYear}-{stardewValleySeason}-{stardewValleyDayOfMonth}";
-            takeScreenshot.Invoke<string>(0.25f, screenshotName);
-            screenshotTakenToday = true;
+        /// <summary>Raised if the screenshot is changed.</summary>
+        /// <param name="screenshotName">The name of the screenshot file.</param>
+        private void MoveScreenshotToCorrectFolder(string screenshotName)
+        {
+            string screenshotNameWithExtension = screenshotName + ".png";
+            string appDataDirectory = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            string stardewValleyScreenshotsDirectory = Path.Combine(appDataDirectory, "StardewValley\\Screenshots");
+            string sourceFile = Path.Combine(stardewValleyScreenshotsDirectory, screenshotNameWithExtension);
+            string saveDirectory = Game1.player.farmName + "-Farm-Screenshots";
+            string saveDirectoryFullPath = Path.Combine(stardewValleyScreenshotsDirectory, saveDirectory);
+            string saveDirectoryAndNewFile = Path.Combine(saveDirectory, screenshotNameWithExtension);
+            string destinationFile = Path.Combine(stardewValleyScreenshotsDirectory, saveDirectoryAndNewFile);
+
+            // create folder if it doesn't exist
+            if (!System.IO.File.Exists(saveDirectoryFullPath))
+            {
+                System.IO.Directory.CreateDirectory(saveDirectoryFullPath);
+            }
+
+            // To move a file or folder to a new location:
+            System.IO.File.Move(sourceFile, destinationFile);
         }
 
         /// <summary>Raised if the screenshot is changed.</summary>
@@ -163,14 +157,6 @@ namespace DailyScreenshot
                         case "winter":
                             stardewValleySeason = "04";
                             break;
-                    }
-
-                    FileInfo screenshot = new FileInfo(e.FullPath);
-                    var correctPath = Path.Combine(screenshotsDirectory.FullName, $"{stardewValleyYear}-{stardewValleySeason}-{stardewValleyDayOfMonth}.png");
-                    var correctFile = new FileInfo(correctPath);
-                    if (!correctFile.Exists)
-                    {
-                        screenshot.CopyTo(correctFile.FullName);
                     }
                 }
                 catch (IOException)

--- a/DailyScreenshot/manifest.json
+++ b/DailyScreenshot/manifest.json
@@ -1,12 +1,12 @@
 ﻿{
   "Name": "Daily Screenshot",
   "Author": "CompSciLauren",
-  "Version": "1.0.1",
+  "Version": "1.1.0",
   "Description": "Automatically takes a daily screenshot of your entire farm.",
   "UniqueID": "CompSciLauren.DailyScreenshot",
   "EntryDll": "DailyScreenshot.dll",
   "MinimumApiVersion": "2.10.0",
-  "UpdateKeys": [ "GitHub:CompSciLauren/stardew-valley-daily-screenshot-mod" ],
+  "UpdateKeys": [ "Nexus:4779", "ModDrop:677025", "Chucklefish:5907", "CurseForge:353698", "GitHub:CompSciLauren/stardew-valley-daily-screenshot-mod" ],
   "Dependencies": [
     {
       "UniqueID": "spacechase0.MapImageExporter",

--- a/DailyScreenshot/manifest.json
+++ b/DailyScreenshot/manifest.json
@@ -6,12 +6,5 @@
   "UniqueID": "CompSciLauren.DailyScreenshot",
   "EntryDll": "DailyScreenshot.dll",
   "MinimumApiVersion": "2.10.0",
-  "UpdateKeys": [ "Nexus:4779", "ModDrop:677025", "Chucklefish:5907", "CurseForge:353698", "GitHub:CompSciLauren/stardew-valley-daily-screenshot-mod" ],
-  "Dependencies": [
-    {
-      "UniqueID": "spacechase0.MapImageExporter",
-      "IsRequired": true,
-      "MinimumVersion": "1.0.6"
-    }
-  ]
+  "UpdateKeys": [ "Nexus:4779", "ModDrop:677025", "Chucklefish:5907", "CurseForge:353698", "GitHub:CompSciLauren/stardew-valley-daily-screenshot-mod" ]
 }

--- a/DailyScreenshot/manifest.json
+++ b/DailyScreenshot/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "Name": "Daily Screenshot",
   "Author": "CompSciLauren",
-  "Version": "1.1.0",
+  "Version": "1.0.2",
   "Description": "Automatically takes a daily screenshot of your entire farm.",
   "UniqueID": "CompSciLauren.DailyScreenshot",
   "EntryDll": "DailyScreenshot.dll",

--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
-# Daily Screenshot - 1.0.1
+# Daily Screenshot v1.0.2
 
 > A Stardew Valley mod that automatically takes a screenshot of your entire farm at the start of each day.
 
 ## Install
 
 1. [Install the latest version of SMAPI](https://smapi.io/).
-2. [Download the latest version of the Map Image Export mod](https://www.nexusmods.com/stardewvalley/mods/1073?tab=description) and unzip it into Stardew Valley/Mods.
 3. Download this mod and unzip it into Stardew Valley/Mods.
 4. Run the game using SMAPI.
 
 ## How to use
 
-The screenshot will be taken automatically. Screenshots will be added in the following location on your computer: C:\Program Files (x86)\Steam\steamapps\common\Stardew Valley\MapExport\Screenshots
+The screenshot will be taken automatically once every in-game day, after you've first left your house. Screenshots are added to your StardewValley/Screenshots folder.
+
+The StardewValley/Screenshots folder can be located by going to the in-game menu, at the very bottom of the Options tab.
 
 Each screenshot is named with "year-season-day.png" numerical format. So on Year 1, Spring, Day 3, the screenshot would be named "01-01-03.png".
 
@@ -23,8 +24,7 @@ Each screenshot is named with "year-season-day.png" numerical format. So on Year
 
 ## Known Issues
 
-- Screenshots currently show all days as having "clear" weather (even if it is raining, snowing, etc). The only exception is that on days that do not actually have clear weather, part of the actual weather can be seen in the upper-left hand corner of the screenshot.
-- No configuration options are currently available in this mod. Configurations will be added in the next major update (v1.1.0). This will include, among other things, configurations for weather (e.g. choosing to allow rainy weather to appear in screenshots, or disabling all weather besides "clear" weather).
+- No configuration options are currently available in this mod. Configurations will be added in the next update (v1.1.0). This will include, among other things, configurations for weather (e.g. choosing to allow rainy weather to appear in screenshots, or disabling all weather besides "clear" weather).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 The screenshot will be taken automatically once every in-game day, after you've first left your house. Screenshots are added to your StardewValley/Screenshots folder.
 
-The StardewValley/Screenshots folder can be located by going to the in-game menu, at the very bottom of the Options tab.
+The StardewValley/Screenshots folder can be located by going to the in-game menu and scrolling to the very bottom of the Options tab.
 
 Each screenshot is named with "year-season-day.png" numerical format. So on Year 1, Spring, Day 3, the screenshot would be named "01-01-03.png".
 


### PR DESCRIPTION
- Fixes all known bugs (#3, #11, #12).
- Adds more update keys so the players will most likely receive a link to a player-friendly website, with GitHub being the last resort update key, meaning GitHub release was updated but other websites were either not updated or are not working (#9).
- Changes destination folder of screenshots to be the more player-friendly option, StardewValley/Screenshots (#14).
- If the player has a screenshot taken but then later restarts the day, another screenshot will be taken and will overwrite the old one (#8).
- No longer requires MapImageExport dependency since the way screenshots are taken was improved while working on the above issues.