### PR TITLE
Fix #29

### DIFF
--- a/DailyScreenshot/ModEntry.cs
+++ b/DailyScreenshot/ModEntry.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
 using Netcode;
 using StardewModdingAPI;
@@ -293,6 +293,7 @@ namespace DailyScreenshot
         /// <param name="e">The event data.</param>
         private void OnReturnedToTitle(object sender, ReturnedToTitleEventArgs e)
         {
+            Helper.Events.GameLoop.DayStarted -= OnDayStarted;
             screenshotTakenToday = false;
             countdownInSeconds = 60;
         }


### PR DESCRIPTION
Fix bug #29 where screenshot gets taken multiples times if save is reloaded.

**How it was resolved:**

The _OnDayStarted_ method is added into _Helper.Events.GameLoop.DayStarted_, inside the method _OnSaveLoaded_. That's why if a user reloaded a save 5 times, the whole _OnDayStarted_ method would execute 5 times as it would have been added one more time at each SaveLoad event.

The fix I made simply remove _OnDayStarted_ from _Helper.Events.GameLoop.DayStarted_ when a player leave a game back to the main menu.
Not sure if this is the better fix because, even if the impact is probably not noticeable, it removes and adds back the method every time a player quit and load a save, a better approach might be to check and add the event method in the listener only if it isn't already in.