### PR TITLE
Add Android version of mod

### DIFF
--- a/DailyScreenshotAndroid/DailyScreenshotAndroid.csproj
+++ b/DailyScreenshotAndroid/DailyScreenshotAndroid.csproj
@@ -7,8 +7,8 @@
     <ProjectGuid>{DD196A2F-C6E1-4FDE-9F05-755114677E16}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>StardewValleyModTemplate</RootNamespace>
-    <AssemblyName>StardewValleyModTemplate</AssemblyName>
+    <RootNamespace>DailyScreenshotAndroid</RootNamespace>
+    <AssemblyName>DailyScreenshotAndroid</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>

--- a/DailyScreenshotAndroid/DailyScreenshotAndroid.csproj
+++ b/DailyScreenshotAndroid/DailyScreenshotAndroid.csproj
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{DD196A2F-C6E1-4FDE-9F05-755114677E16}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>StardewValleyModTemplate</RootNamespace>
+    <AssemblyName>StardewValleyModTemplate</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ModEntry.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="manifest.json" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+  </Target>
+</Project>

--- a/DailyScreenshotAndroid/DailyScreenshotAndroid.sln
+++ b/DailyScreenshotAndroid/DailyScreenshotAndroid.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.779
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DailyScreenshotAndroid", "DailyScreenshotAndroid.csproj", "{DD196A2F-C6E1-4FDE-9F05-755114677E16}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{DD196A2F-C6E1-4FDE-9F05-755114677E16}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DD196A2F-C6E1-4FDE-9F05-755114677E16}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DD196A2F-C6E1-4FDE-9F05-755114677E16}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DD196A2F-C6E1-4FDE-9F05-755114677E16}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {585FB4A2-3EF6-4888-8C8D-DB02A7967FC2}
+	EndGlobalSection
+EndGlobal

--- a/DailyScreenshotAndroid/ModEntry.cs
+++ b/DailyScreenshotAndroid/ModEntry.cs
@@ -18,6 +18,13 @@ namespace DailyScreenshot
         private int countdownInSeconds = 60;
         private ulong saveFileCode;
 
+        /// <summary>
+        /// Helper function for sending error messages
+        /// Always display even if verbose logging is off
+        /// </summary>
+        /// <param name="message">text to send</param>
+        internal void MError(string message) => Monitor.Log(message, LogLevel.Error);
+
         /// <summary>The mod entry point, called after the mod is first loaded.</summary>
         /// <param name="helper">Provides simplified APIs for writing mods.</param>
         public override void Entry(IModHelper helper)
@@ -182,7 +189,7 @@ namespace DailyScreenshot
             }
             catch (Exception ex)
             {
-                Monitor.Log($"Error moving file '{screenshotNameWithExtension}' into {saveFilePath} folder. Technical details:\n{ex}", LogLevel.Error);
+                MError($"Error moving file '{screenshotNameWithExtension}' to {saveFilePath}. Technical details:\n{ex}");
             }
         }
 

--- a/DailyScreenshotAndroid/ModEntry.cs
+++ b/DailyScreenshotAndroid/ModEntry.cs
@@ -56,7 +56,6 @@ namespace DailyScreenshot
 
             EnqueueAction(() => {
                 TakeScreenshot();
-                MoveScreenshotToCorrectFolder("Farm"); // screenshotName
             });
         }
 
@@ -88,9 +87,6 @@ namespace DailyScreenshot
         /// <summary>Takes a screenshot of the entire farm.</summary>
         private void TakeScreenshot()
         {
-            ConvertInGameDateToNumericFormat();
-
-            string screenshotName = $"{stardewValleyYear}-{stardewValleySeason}-{stardewValleyDayOfMonth}";
             Helper.ConsoleCommands.Trigger("export", new[] { "Farm", "all" });
             screenshotTakenToday = true;
         }
@@ -144,13 +140,17 @@ namespace DailyScreenshot
         /// <param name="screenshotName">The name of the screenshot file.</param>
         private void MoveScreenshotToCorrectFolder(string screenshotName)
         {
+            ConvertInGameDateToNumericFormat();
+            string newScreenshotName = $"{stardewValleyYear}-{stardewValleySeason}-{stardewValleyDayOfMonth}";
+            string newScreenshotNameWithExtension = newScreenshotName + ".png";
+
             screenshotName = "Farm";
             // gather directory and file paths
             string screenshotNameWithExtension = screenshotName + ".png";
             string saveFilePath = screenshotsDirectory.ToString();
 
             string sourceFile = Path.Combine(exportDirectory.ToString(), screenshotNameWithExtension);
-            string destinationFile = Path.Combine(exportDirectory.ToString(), saveFilePath, screenshotNameWithExtension);
+            string destinationFile = Path.Combine(exportDirectory.ToString(), saveFilePath, newScreenshotNameWithExtension);
 
             string saveDirectoryFullPath = Path.Combine(exportDirectory.ToString(), saveFilePath);
 
@@ -183,6 +183,7 @@ namespace DailyScreenshot
         {
             screenshotTakenToday = false;
             countdownInSeconds = 60;
+            MoveScreenshotToCorrectFolder("Farm"); // screenshotName
         }
     }
 }

--- a/DailyScreenshotAndroid/ModEntry.cs
+++ b/DailyScreenshotAndroid/ModEntry.cs
@@ -1,40 +1,145 @@
-﻿using System;
-using Microsoft.Xna.Framework;
-using StardewModdingAPI;
+﻿using StardewModdingAPI;
 using StardewModdingAPI.Events;
-using StardewModdingAPI.Utilities;
 using StardewValley;
+using System.IO;
+using System.Linq;
 
 namespace DailyScreenshotAndroid
 {
     /// <summary>The mod entry point.</summary>
     public class ModEntry : Mod
     {
-        /*********
-        ** Public methods
-        *********/
+        private DirectoryInfo exportDirectory, screenshotsDirectory;
+        private string stardewValleyLocation = "Farm";
+        private string stardewValleyYear, stardewValleySeason, stardewValleyDayOfMonth;
+        private bool screenshotTakenToday = false;
+
         /// <summary>The mod entry point, called after the mod is first loaded.</summary>
         /// <param name="helper">Provides simplified APIs for writing mods.</param>
         public override void Entry(IModHelper helper)
         {
-            helper.Events.Input.ButtonPressed += OnButtonPressed;
+            var stardewValleyRootDirectory = new DirectoryInfo(Constants.ExecutionPath);
+            exportDirectory = stardewValleyRootDirectory.EnumerateDirectories("MapExport").FirstOrDefault();
+            if (exportDirectory == null)
+            {
+                exportDirectory = stardewValleyRootDirectory.CreateSubdirectory("MapExport");
+            }
+            CreateFileSystemWatcher();
+            helper.Events.GameLoop.SaveLoaded += OnSaveLoaded;
         }
 
-
-        /*********
-        ** Private methods
-        *********/
-        /// <summary>Raised after the player presses a button on the keyboard, controller, or mouse.</summary>
+        /// <summary>Raised after the save file is loaded.</summary>
         /// <param name="sender">The event sender.</param>
         /// <param name="e">The event data.</param>
-        private void OnButtonPressed(object sender, ButtonPressedEventArgs e)
+        private void OnSaveLoaded(object sender, SaveLoadedEventArgs e)
         {
-            // ignore if player hasn't loaded a save yet
-            if (!Context.IsWorldReady)
-                return;
+            var farmName = Game1.player.farmName;
+            var directoryName = $"{farmName}-Farm-Screenshots";
+            screenshotsDirectory = exportDirectory.CreateSubdirectory(directoryName);
+            Helper.Events.Player.Warped += OnNewLocationEntered;
+            Helper.Events.GameLoop.DayEnding += SetScreenshotTakenTodayToFalse;
+        }
 
-            // print button presses to the console window
-            Monitor.Log($"{Game1.player.Name} pressed {e.Button}.", LogLevel.Debug);
+        /// <summary>Creates a new FileSystemWatcher and set its properties.</summary>
+        private void CreateFileSystemWatcher()
+        {
+            FileSystemWatcher watcher = new FileSystemWatcher
+            {
+
+                // Set watcher path.
+                Path = exportDirectory.FullName,
+
+                // Watch for changes in LastAccess and LastWrite times, and the renaming of files or directories.
+                NotifyFilter = NotifyFilters.LastAccess
+                                 | NotifyFilters.LastWrite
+                                 | NotifyFilters.FileName
+                                 | NotifyFilters.DirectoryName,
+
+                // Only watch Portable Network Graphics files.
+                Filter = $"*.png"
+            };
+
+            // Add event handlers.
+            watcher.Changed += OnScreenshotChanged;
+            watcher.Created += OnScreenshotChanged;
+
+            // Begin watching.
+            watcher.EnableRaisingEvents = true;
+        }
+
+        /// <summary>Raised after the player enters a new location.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event data.</param>
+        private void OnNewLocationEntered(object sender, WarpedEventArgs e)
+        {
+            if (e.NewLocation is Farm && !screenshotTakenToday)
+            {
+                Helper.ConsoleCommands.Trigger("export", new[] { stardewValleyLocation, "all" });
+                screenshotTakenToday = true;
+                Monitor.Log("Screenshot taken", LogLevel.Warn);
+            }
+        }
+
+        /// <summary>Raised if the screenshot is changed.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event data.</param>
+        private void OnScreenshotChanged(object sender, FileSystemEventArgs e)
+        {
+            var fileName = Path.GetFileNameWithoutExtension(e.FullPath);
+            if (fileName == stardewValleyLocation &&
+                (e.ChangeType == WatcherChangeTypes.Created || e.ChangeType == WatcherChangeTypes.Changed))
+            {
+                try
+                {
+                    stardewValleyYear = Game1.Date.Year.ToString();
+                    stardewValleySeason = Game1.Date.Season.ToString();
+                    stardewValleyDayOfMonth = Game1.Date.DayOfMonth.ToString();
+
+                    if (int.Parse(stardewValleyYear) < 10)
+                    {
+                        stardewValleyYear = "0" + stardewValleyYear;
+                    }
+                    if (int.Parse(stardewValleyDayOfMonth) < 10)
+                    {
+                        stardewValleyDayOfMonth = "0" + stardewValleyDayOfMonth;
+                    }
+
+                    switch (Game1.Date.Season)
+                    {
+                        case "spring":
+                            stardewValleySeason = "01";
+                            break;
+                        case "summer":
+                            stardewValleySeason = "02";
+                            break;
+                        case "fall":
+                            stardewValleySeason = "03";
+                            break;
+                        case "winter":
+                            stardewValleySeason = "04";
+                            break;
+                    }
+
+                    FileInfo screenshot = new FileInfo(e.FullPath);
+                    var correctPath = Path.Combine(screenshotsDirectory.FullName, $"{stardewValleyYear}-{stardewValleySeason}-{stardewValleyDayOfMonth}.png");
+                    var correctFile = new FileInfo(correctPath);
+                    if (!correctFile.Exists)
+                    {
+                        screenshot.CopyTo(correctFile.FullName);
+                    }
+                }
+                catch (IOException)
+                {
+                }
+            }
+        }
+
+        /// <summary>Sets screenshotTakenToday variable to false.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event data.</param>
+        private void SetScreenshotTakenTodayToFalse(object sender, DayEndingEventArgs e)
+        {
+            screenshotTakenToday = false;
         }
     }
 }

--- a/DailyScreenshotAndroid/ModEntry.cs
+++ b/DailyScreenshotAndroid/ModEntry.cs
@@ -82,6 +82,10 @@ namespace DailyScreenshot
                 while (_actions.Count > 0)
                     _actions.Dequeue().Invoke();
             }
+            if (countdownInSeconds == -1)
+            {
+                MoveScreenshotToCorrectFolder("Farm"); // screenshotName
+            }
         }
 
         /// <summary>Takes a screenshot of the entire farm.</summary>
@@ -183,7 +187,6 @@ namespace DailyScreenshot
         {
             screenshotTakenToday = false;
             countdownInSeconds = 60;
-            MoveScreenshotToCorrectFolder("Farm"); // screenshotName
         }
     }
 }

--- a/DailyScreenshotAndroid/ModEntry.cs
+++ b/DailyScreenshotAndroid/ModEntry.cs
@@ -14,9 +14,9 @@ namespace DailyScreenshot
         private DirectoryInfo exportDirectory, screenshotsDirectory;
         private string stardewValleyYear, stardewValleySeason, stardewValleyDayOfMonth;
         private bool screenshotTakenToday = false;
-        private string theScreenshotName = "null";
-        int countdownInSeconds = 60;
-        ulong saveFileCode;
+        private string displayScreenshotFileName = "null";
+        private int countdownInSeconds = 60;
+        private ulong saveFileCode;
 
         /// <summary>The mod entry point, called after the mod is first loaded.</summary>
         /// <param name="helper">Provides simplified APIs for writing mods.</param>
@@ -52,7 +52,7 @@ namespace DailyScreenshot
         private void OnDayStarted(object sender, DayStartedEventArgs e)
         {
             ConvertInGameDateToNumericFormat();
-            theScreenshotName = $"{stardewValleyYear}-{stardewValleySeason}-{stardewValleyDayOfMonth}.png";
+            displayScreenshotFileName = $"{stardewValleyYear}-{stardewValleySeason}-{stardewValleyDayOfMonth}.png";
 
             Helper.Events.GameLoop.UpdateTicked -= OnUpdateTicked;
             screenshotTakenToday = false;
@@ -97,7 +97,7 @@ namespace DailyScreenshot
         private void TakeScreenshot()
         {
             Helper.ConsoleCommands.Trigger("export", new[] { "Farm", "all" });
-            Game1.addHUDMessage(new HUDMessage(theScreenshotName, 6));
+            Game1.addHUDMessage(new HUDMessage(displayScreenshotFileName, 6));
             Game1.playSound("cameraNoise");
             screenshotTakenToday = true;
         }

--- a/DailyScreenshotAndroid/ModEntry.cs
+++ b/DailyScreenshotAndroid/ModEntry.cs
@@ -1,31 +1,27 @@
 ﻿using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewValley;
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
-namespace DailyScreenshotAndroid
+namespace DailyScreenshot
 {
     /// <summary>The mod entry point.</summary>
     public class ModEntry : Mod
     {
-        private DirectoryInfo exportDirectory, screenshotsDirectory;
-        private string stardewValleyLocation = "Farm";
+        IReflectedMethod takeScreenshot = null;
         private string stardewValleyYear, stardewValleySeason, stardewValleyDayOfMonth;
         private bool screenshotTakenToday = false;
+        int countdownInSeconds = 60;
+        ulong saveFileCode;
 
         /// <summary>The mod entry point, called after the mod is first loaded.</summary>
         /// <param name="helper">Provides simplified APIs for writing mods.</param>
         public override void Entry(IModHelper helper)
         {
-            var stardewValleyRootDirectory = new DirectoryInfo(Constants.ExecutionPath);
-            exportDirectory = stardewValleyRootDirectory.EnumerateDirectories("MapExport").FirstOrDefault();
-            if (exportDirectory == null)
-            {
-                exportDirectory = stardewValleyRootDirectory.CreateSubdirectory("MapExport");
-            }
-            CreateFileSystemWatcher();
-            helper.Events.GameLoop.SaveLoaded += OnSaveLoaded;
+            Helper.Events.GameLoop.SaveLoaded += OnSaveLoaded;
         }
 
         /// <summary>Raised after the save file is loaded.</summary>
@@ -33,113 +29,152 @@ namespace DailyScreenshotAndroid
         /// <param name="e">The event data.</param>
         private void OnSaveLoaded(object sender, SaveLoadedEventArgs e)
         {
-            var farmName = Game1.player.farmName;
-            var directoryName = $"{farmName}-Farm-Screenshots";
-            screenshotsDirectory = exportDirectory.CreateSubdirectory(directoryName);
-            Helper.Events.Player.Warped += OnNewLocationEntered;
-            Helper.Events.GameLoop.DayEnding += SetScreenshotTakenTodayToFalse;
+            saveFileCode = Game1.uniqueIDForThisGame;
+            Helper.Events.Player.Warped += OnWarped;
+            Helper.Events.GameLoop.DayStarted += OnDayStarted;
+            Helper.Events.GameLoop.ReturnedToTitle += OnReturnedToTitle;
         }
 
-        /// <summary>Creates a new FileSystemWatcher and set its properties.</summary>
-        private void CreateFileSystemWatcher()
+        /// <summary>Raised after day has started.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event data.</param>
+        private void OnDayStarted(object sender, DayStartedEventArgs e)
         {
-            FileSystemWatcher watcher = new FileSystemWatcher
-            {
+            Helper.Events.GameLoop.UpdateTicked -= OnUpdateTicked;
+            screenshotTakenToday = false;
+            countdownInSeconds = 60;
 
-                // Set watcher path.
-                Path = exportDirectory.FullName,
-
-                // Watch for changes in LastAccess and LastWrite times, and the renaming of files or directories.
-                NotifyFilter = NotifyFilters.LastAccess
-                                 | NotifyFilters.LastWrite
-                                 | NotifyFilters.FileName
-                                 | NotifyFilters.DirectoryName,
-
-                // Only watch Portable Network Graphics files.
-                Filter = $"*.png"
-            };
-
-            // Add event handlers.
-            watcher.Changed += OnScreenshotChanged;
-            watcher.Created += OnScreenshotChanged;
-
-            // Begin watching.
-            watcher.EnableRaisingEvents = true;
+            EnqueueAction(() => {
+                TakeScreenshot();
+            });
         }
 
         /// <summary>Raised after the player enters a new location.</summary>
         /// <param name="sender">The event sender.</param>
         /// <param name="e">The event data.</param>
-        private void OnNewLocationEntered(object sender, WarpedEventArgs e)
+        private void OnWarped(object sender, WarpedEventArgs e)
         {
             if (e.NewLocation is Farm && !screenshotTakenToday)
             {
-                Helper.ConsoleCommands.Trigger("export", new[] { stardewValleyLocation, "all" });
-                screenshotTakenToday = true;
-                Monitor.Log("Screenshot taken", LogLevel.Warn);
+                Helper.Events.GameLoop.UpdateTicked += OnUpdateTicked;
             }
         }
 
-        /// <summary>Raised if the screenshot is changed.</summary>
+        /// <summary>Raised after game state is updated.</summary>
         /// <param name="sender">The event sender.</param>
         /// <param name="e">The event data.</param>
-        private void OnScreenshotChanged(object sender, FileSystemEventArgs e)
+        private void OnUpdateTicked(object sender, UpdateTickedEventArgs e)
         {
-            var fileName = Path.GetFileNameWithoutExtension(e.FullPath);
-            if (fileName == stardewValleyLocation &&
-                (e.ChangeType == WatcherChangeTypes.Created || e.ChangeType == WatcherChangeTypes.Changed))
+            countdownInSeconds--;
+
+            if (countdownInSeconds == 0)
             {
-                try
-                {
-                    stardewValleyYear = Game1.Date.Year.ToString();
-                    stardewValleySeason = Game1.Date.Season.ToString();
-                    stardewValleyDayOfMonth = Game1.Date.DayOfMonth.ToString();
-
-                    if (int.Parse(stardewValleyYear) < 10)
-                    {
-                        stardewValleyYear = "0" + stardewValleyYear;
-                    }
-                    if (int.Parse(stardewValleyDayOfMonth) < 10)
-                    {
-                        stardewValleyDayOfMonth = "0" + stardewValleyDayOfMonth;
-                    }
-
-                    switch (Game1.Date.Season)
-                    {
-                        case "spring":
-                            stardewValleySeason = "01";
-                            break;
-                        case "summer":
-                            stardewValleySeason = "02";
-                            break;
-                        case "fall":
-                            stardewValleySeason = "03";
-                            break;
-                        case "winter":
-                            stardewValleySeason = "04";
-                            break;
-                    }
-
-                    FileInfo screenshot = new FileInfo(e.FullPath);
-                    var correctPath = Path.Combine(screenshotsDirectory.FullName, $"{stardewValleyYear}-{stardewValleySeason}-{stardewValleyDayOfMonth}.png");
-                    var correctFile = new FileInfo(correctPath);
-                    if (!correctFile.Exists)
-                    {
-                        screenshot.CopyTo(correctFile.FullName);
-                    }
-                }
-                catch (IOException)
-                {
-                }
+                while (_actions.Count > 0)
+                    _actions.Dequeue().Invoke();
             }
         }
 
-        /// <summary>Sets screenshotTakenToday variable to false.</summary>
+        /// <summary>Takes a screenshot of the entire farm.</summary>
+        private void TakeScreenshot()
+        {
+            ConvertInGameDateToNumericFormat();
+
+            string screenshotName = $"{stardewValleyYear}-{stardewValleySeason}-{stardewValleyDayOfMonth}";
+            Helper.ConsoleCommands.Trigger("export", new[] { "Farm", "all" });
+            Monitor.Log("Screenshot Taken", LogLevel.Debug);
+            screenshotTakenToday = true;
+
+            MoveScreenshotToCorrectFolder(screenshotName);
+        }
+
+        private Queue<Action> _actions = new Queue<Action>();
+
+        /// <summary>Allows ability to enqueue actions to the queue.</summary>
+        /// <param name="action">The action.</param>
+        public void EnqueueAction(Action action)
+        {
+            if (action == null) return;
+            _actions.Enqueue(action);
+        }
+
+        /// <summary>Fixes the screenshot name to be in the proper format.</summary>
+        private void ConvertInGameDateToNumericFormat()
+        {
+            stardewValleyYear = Game1.Date.Year.ToString();
+            stardewValleySeason = Game1.Date.Season.ToString();
+            stardewValleyDayOfMonth = Game1.Date.DayOfMonth.ToString();
+
+            // fix year and month to be in numeric format
+            if (int.Parse(stardewValleyYear) < 10)
+            {
+                stardewValleyYear = "0" + stardewValleyYear;
+            }
+            if (int.Parse(stardewValleyDayOfMonth) < 10)
+            {
+                stardewValleyDayOfMonth = "0" + stardewValleyDayOfMonth;
+            }
+
+            // fix season to be in numeric format
+            switch (Game1.Date.Season)
+            {
+                case "spring":
+                    stardewValleySeason = "01";
+                    break;
+                case "summer":
+                    stardewValleySeason = "02";
+                    break;
+                case "fall":
+                    stardewValleySeason = "03";
+                    break;
+                case "winter":
+                    stardewValleySeason = "04";
+                    break;
+            }
+        }
+
+        /// <summary>Moves screenshot into StardewValley/Screenshots directory, in the save file folder.</summary>
+        /// <param name="screenshotName">The name of the screenshot file.</param>
+        private void MoveScreenshotToCorrectFolder(string screenshotName)
+        {
+            // gather directory and file paths
+            string screenshotNameWithExtension = screenshotName + ".png";
+            string stardewValleyScreenshotsDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "StardewValley", "Screenshots");
+            string saveFilePath = Game1.player.farmName + "-Farm-Screenshots-" + saveFileCode;
+
+            string sourceFile = Path.Combine(stardewValleyScreenshotsDirectory, screenshotNameWithExtension);
+            string destinationFile = Path.Combine(stardewValleyScreenshotsDirectory, saveFilePath, screenshotNameWithExtension);
+
+            string saveDirectoryFullPath = Path.Combine(stardewValleyScreenshotsDirectory, saveFilePath);
+
+            // create save directory if it doesn't already exist
+            if (!File.Exists(saveDirectoryFullPath))
+            {
+                Directory.CreateDirectory(saveDirectoryFullPath);
+            }
+
+            // delete old version of screenshot if one exists
+            if (File.Exists(destinationFile))
+            {
+                File.Delete(destinationFile);
+            }
+
+            try
+            {
+                File.Move(sourceFile, destinationFile);
+            }
+            catch (Exception ex)
+            {
+                Monitor.Log($"Error moving file '{screenshotNameWithExtension}' into {saveFilePath} folder. Technical details:\n{ex}", LogLevel.Error);
+            }
+        }
+
+        /// <summary>Raised after the player returns to the title screen.</summary>
         /// <param name="sender">The event sender.</param>
         /// <param name="e">The event data.</param>
-        private void SetScreenshotTakenTodayToFalse(object sender, DayEndingEventArgs e)
+        private void OnReturnedToTitle(object sender, ReturnedToTitleEventArgs e)
         {
             screenshotTakenToday = false;
+            countdownInSeconds = 60;
         }
     }
 }

--- a/DailyScreenshotAndroid/ModEntry.cs
+++ b/DailyScreenshotAndroid/ModEntry.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.Xna.Framework;
+using StardewModdingAPI;
+using StardewModdingAPI.Events;
+using StardewModdingAPI.Utilities;
+using StardewValley;
+
+namespace DailyScreenshotAndroid
+{
+    /// <summary>The mod entry point.</summary>
+    public class ModEntry : Mod
+    {
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>The mod entry point, called after the mod is first loaded.</summary>
+        /// <param name="helper">Provides simplified APIs for writing mods.</param>
+        public override void Entry(IModHelper helper)
+        {
+            helper.Events.Input.ButtonPressed += OnButtonPressed;
+        }
+
+
+        /*********
+        ** Private methods
+        *********/
+        /// <summary>Raised after the player presses a button on the keyboard, controller, or mouse.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event data.</param>
+        private void OnButtonPressed(object sender, ButtonPressedEventArgs e)
+        {
+            // ignore if player hasn't loaded a save yet
+            if (!Context.IsWorldReady)
+                return;
+
+            // print button presses to the console window
+            Monitor.Log($"{Game1.player.Name} pressed {e.Button}.", LogLevel.Debug);
+        }
+    }
+}

--- a/DailyScreenshotAndroid/ModEntry.cs
+++ b/DailyScreenshotAndroid/ModEntry.cs
@@ -14,6 +14,7 @@ namespace DailyScreenshot
         private DirectoryInfo exportDirectory, screenshotsDirectory;
         private string stardewValleyYear, stardewValleySeason, stardewValleyDayOfMonth;
         private bool screenshotTakenToday = false;
+        private string theScreenshotName = "null";
         int countdownInSeconds = 60;
         ulong saveFileCode;
 
@@ -50,6 +51,9 @@ namespace DailyScreenshot
         /// <param name="e">The event data.</param>
         private void OnDayStarted(object sender, DayStartedEventArgs e)
         {
+            ConvertInGameDateToNumericFormat();
+            theScreenshotName = $"{stardewValleyYear}-{stardewValleySeason}-{stardewValleyDayOfMonth}.png";
+
             Helper.Events.GameLoop.UpdateTicked -= OnUpdateTicked;
             screenshotTakenToday = false;
             countdownInSeconds = 60;
@@ -85,6 +89,7 @@ namespace DailyScreenshot
             if (countdownInSeconds == -1)
             {
                 MoveScreenshotToCorrectFolder("Farm"); // screenshotName
+                Helper.Events.GameLoop.UpdateTicked -= OnUpdateTicked;
             }
         }
 
@@ -92,6 +97,8 @@ namespace DailyScreenshot
         private void TakeScreenshot()
         {
             Helper.ConsoleCommands.Trigger("export", new[] { "Farm", "all" });
+            Game1.addHUDMessage(new HUDMessage(theScreenshotName, 6));
+            Game1.playSound("cameraNoise");
             screenshotTakenToday = true;
         }
 
@@ -144,7 +151,6 @@ namespace DailyScreenshot
         /// <param name="screenshotName">The name of the screenshot file.</param>
         private void MoveScreenshotToCorrectFolder(string screenshotName)
         {
-            ConvertInGameDateToNumericFormat();
             string newScreenshotName = $"{stardewValleyYear}-{stardewValleySeason}-{stardewValleyDayOfMonth}";
             string newScreenshotNameWithExtension = newScreenshotName + ".png";
 

--- a/DailyScreenshotAndroid/Properties/AssemblyInfo.cs
+++ b/DailyScreenshotAndroid/Properties/AssemblyInfo.cs
@@ -5,11 +5,11 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("StardewValleyModTemplate")]
+[assembly: AssemblyTitle("DailyScreenshotAndroid")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("StardewValleyModTemplate")]
+[assembly: AssemblyProduct("DailyScreenshotAndroid")]
 [assembly: AssemblyCopyright("Copyright ©  2020")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]

--- a/DailyScreenshotAndroid/Properties/AssemblyInfo.cs
+++ b/DailyScreenshotAndroid/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("StardewValleyModTemplate")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("StardewValleyModTemplate")]
+[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("dd196a2f-c6e1-4fde-9f05-755114677e16")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/DailyScreenshotAndroid/manifest.json
+++ b/DailyScreenshotAndroid/manifest.json
@@ -1,0 +1,9 @@
+﻿{
+  "Name": "Daily Screenshot Android",
+  "Author": "CompSciLauren",
+  "Version": "1.0.0",
+  "Description": "Automatically takes a daily screenshot of your entire farm.",
+  "UniqueID": "CompSciLauren.DailyScreenshotAndroid",
+  "EntryDll": "DailyScreenshotAndroid.dll",
+  "MinimumApiVersion": "2.10.0"
+}

--- a/DailyScreenshotAndroid/manifest.json
+++ b/DailyScreenshotAndroid/manifest.json
@@ -6,6 +6,7 @@
   "UniqueID": "CompSciLauren.DailyScreenshotAndroid",
   "EntryDll": "StardewValleyModTemplate.dll",
   "MinimumApiVersion": "2.10.0",
+  "UpdateKeys": [ "Chucklefish:5953" ],
   "Dependencies": [
     {
       "UniqueID": "spacechase0.MapImageExporter",

--- a/DailyScreenshotAndroid/manifest.json
+++ b/DailyScreenshotAndroid/manifest.json
@@ -4,6 +4,13 @@
   "Version": "1.0.0",
   "Description": "Automatically takes a daily screenshot of your entire farm.",
   "UniqueID": "CompSciLauren.DailyScreenshotAndroid",
-  "EntryDll": "DailyScreenshotAndroid.dll",
-  "MinimumApiVersion": "2.10.0"
+  "EntryDll": "StardewValleyModTemplate.dll",
+  "MinimumApiVersion": "2.10.0",
+  "Dependencies": [
+    {
+      "UniqueID": "spacechase0.MapImageExporter",
+      "IsRequired": true,
+      "MinimumVersion": "1.0.6"
+    }
+  ]
 }

--- a/DailyScreenshotAndroid/packages.config
+++ b/DailyScreenshotAndroid/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="3.1.0" targetFramework="net452" />
+</packages>

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Releases can be found at the following websites:
 - [CurseForge](https://www.curseforge.com/stardewvalley/mods/daily-screenshot)
 - [ModDrop](https://www.moddrop.com/stardew-valley/mods/677025-daily-screenshot)
 
+For Android users, releases can be found at the following websites:
+- [NexusMods](https://www.nexusmods.com/stardewvalley/mods/4779)
+- [Chucklefish](https://community.playstarbound.com/resources/daily-screenshot-android.5954/)
+
 ## Features
 
 - One screenshot is automatically taken of your entire farm every day as soon as you leave your house.


### PR DESCRIPTION
### Summary
This adds an Android-compatible version of the mod. It is currently only a basic version, with no configuration options. It requires the Map Image Export mod as a dependency.

### Why a separate Android version is necessary
The mod utilizes a Stardew Valley 1.4 feature for capturing screenshots. That specific feature is not currently available on Android. In order for Android users to be able to use this mod, there needs to be a separate Android version that relies on a different screenshot capturing method. The method for Android is one that depends on the Map Image Export mod.