### PR TITLE
Adding 'Generic Mod Config Menu' mod integration to resolve issue #42…

### DIFF
--- a/DailyScreenshot/DailyScreenshot.csproj
+++ b/DailyScreenshot/DailyScreenshot.csproj
@@ -47,6 +47,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="dependencys\GenericModConfigMenuAPI.cs" />
     <Compile Include="ModConfig.cs" />
     <Compile Include="ModEntry.cs" />
     <Compile Include="ModRule.cs" />
@@ -57,6 +58,7 @@
     <None Include="manifest.json" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/DailyScreenshot/ModConfig.cs
+++ b/DailyScreenshot/ModConfig.cs
@@ -54,6 +54,21 @@ namespace DailyScreenshot
         public const int DEFAULT_END_TIME = 2600;
 
         /// <summary>
+        /// Configurable toggle for auditory effects when taking screenshot.
+        /// </summary>
+        public bool auditoryEffects = true;
+
+        /// <summary>
+        /// Configurable toggle for visual effects when taking screenshot.
+        /// </summary>
+        public bool visualEffects = true;
+
+        /// <summary>
+        /// Configurable toggle for ingame notifications when taking screenshot.
+        /// </summary>
+        public bool screenshotNotifications = true;
+
+        /// <summary>
         /// Rules loaded from the config file
         /// </summary>
         public List<ModRule> SnapshotRules { get; set; } = new List<ModRule>();

--- a/DailyScreenshot/ModEntry.cs
+++ b/DailyScreenshot/ModEntry.cs
@@ -384,6 +384,54 @@ namespace DailyScreenshot
         /// <param name="e">The event data.</param>
         private void OnGameLaunched(object sender, GameLaunchedEventArgs e)
         {
+            // add Generic Mod Config Menu integration
+            var gmcmApi = Helper.ModRegistry.GetApi<GenericModConfigMenuAPI>("spacechase0.GenericModConfigMenu");
+            if (gmcmApi != null)
+            {
+                gmcmApi.RegisterModConfig(ModManifest, () => m_config = new ModConfig(), () => Helper.WriteConfig(m_config));
+                gmcmApi.RegisterLabel(ModManifest, "Effect control", "Toggel auditory and visual effects as well as notifications.");
+
+                gmcmApi.RegisterSimpleOption(
+                    ModManifest,
+                    "Auditory effects",
+                    "Toggles if a camera sound plays whenever a screenshot was taken.",
+                    () => m_config.auditoryEffects,
+                    (bool val) => m_config.auditoryEffects = val
+                );
+
+                gmcmApi.RegisterSimpleOption(
+                    ModManifest,
+                    "Visual effects",
+                    "Toggles if the screen flashes whenever a screenshot was taken.",
+                    () => m_config.visualEffects,
+                    (bool val) => m_config.visualEffects = val
+                );
+
+                gmcmApi.RegisterSimpleOption(
+                    ModManifest,
+                    "Notifications",
+                    "Toggles if a notification is displayed whenever a screenshot was taken.",
+                    () => m_config.screenshotNotifications,
+                    (bool val) => m_config.screenshotNotifications = val
+                );
+
+
+                gmcmApi.RegisterLabel(
+                    ModManifest, 
+                    "!!!DISCLAIMER!!! (Hover to reveal)",
+                    "This \"Generic Mod Config Menu\" integration does not \ninclude all possible mod configurations!\n"
+                    + "To configure the screenshot rules edit the config.json \nfile located at your Mods folder.\n"
+                    + "For this purpose, read the config section on the \nrespective download page.\n\n"
+                    + "Note, that using the default button below will reset \nthe entire config file (including the screenshot rules)!\n"
+                    + "Changing and saving the settings shown here \nwill NOT override/reset your set screenshot rules."
+                );
+
+                MInfo("Added \"DailyScreenshot\" config menu with \"Generic Mod Config Menu\".");
+            }
+            else {
+                MInfo("This mod supports the \"Generic Mod Config Menu\" mod but it is not installed!");
+            }
+
             // Move this to OnDayStart and only register what is needed
             Helper.Events.GameLoop.DayStarted += OnDayStarted;
             Helper.Events.GameLoop.ReturnedToTitle += OnReturnedToTitle;
@@ -519,7 +567,12 @@ namespace DailyScreenshot
         private void TakeScreenshot(ModRule rule)
         {
             string ssPath = rule.GetFileName();
-            Game1.flashAlpha = 1f;
+
+            if (m_config.visualEffects)
+            {
+                Game1.flashAlpha = 1f;
+            }
+
             if (null != ssPath)
             {
                 MTrace($"ssPath = \"{ssPath}\"");
@@ -533,7 +586,12 @@ namespace DailyScreenshot
             );
             FileInfo mapScreenshot = new FileInfo(Path.Combine(DefaultSSdirectory.FullName, mapScreenshotPath));
             MTrace($"Snapshot saved to {mapScreenshot.FullName}");
-            Game1.playSound("cameraNoise");
+
+            if (m_config.auditoryEffects)
+            {
+                Game1.playSound("cameraNoise");
+            }
+
             if (ModConfig.DEFAULT_STRING != rule.Directory)
             {
                 EnqueueAction(() =>
@@ -550,8 +608,15 @@ namespace DailyScreenshot
         /// </summary>
         /// <param name="rule">Rule to use for HUD message</param>
         // Adding space based on user feedback
-        private void DisplayRuleHUD(ModRule rule) =>
-            Game1.addHUDMessage(new HUDMessage(" " + rule.Name, HUDMessage.screenshot_type));
+        private void DisplayRuleHUD(ModRule rule)
+        {
+            if (m_config.screenshotNotifications)
+            {
+                Game1.addHUDMessage(
+                    new HUDMessage(" " + rule.Name, HUDMessage.screenshot_type)
+                );
+            }
+        }
 
         /// <summary>
         /// Recursively cleanup empty directories

--- a/DailyScreenshot/dependencys/GenericModConfigMenuAPI.cs
+++ b/DailyScreenshot/dependencys/GenericModConfigMenuAPI.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using StardewModdingAPI;
+using System;
+
+namespace DailyScreenshot
+{
+
+    public interface GenericModConfigMenuAPI
+    {
+        void RegisterModConfig(IManifest mod, Action revertToDefault, Action saveToFile);
+
+        void RegisterLabel(IManifest mod, string labelName, string labelDesc);
+        void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<bool> optionGet, Action<bool> optionSet);
+        void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<int> optionGet, Action<int> optionSet);
+        void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<float> optionGet, Action<float> optionSet);
+        void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<string> optionGet, Action<string> optionSet);
+        void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<SButton> optionGet, Action<SButton> optionSet);
+
+        void RegisterClampedOption(IManifest mod, string optionName, string optionDesc, Func<int> optionGet, Action<int> optionSet, int min, int max);
+        void RegisterClampedOption(IManifest mod, string optionName, string optionDesc, Func<float> optionGet, Action<float> optionSet, float min, float max);
+
+        void RegisterChoiceOption(IManifest mod, string optionName, string optionDesc, Func<string> optionGet, Action<string> optionSet, string[] choices);
+
+        void RegisterComplexOption(IManifest mod, string optionName, string optionDesc,
+                                   Func<Vector2, object, object> widgetUpdate,
+                                   Func<SpriteBatch, Vector2, object, object> widgetDraw,
+                                   Action<object> onSave);
+    }
+}


### PR DESCRIPTION
… in og repo.

## Summary

- The sound/visual effect and the notification can now be switched on or off by config file. 
- Integrated "[Generic Mod Config Menu](https://github.com/spacechase0/GenericModConfigMenu)" capabilities to your implementation. 


Therefore added 3 new boolean fields in the `ModsConfig.cs` class and altered the `OnGameLaunched` method in `ModEntry.cs`.
I used the [this example code](https://gist.github.com/spacechase0/2d8d4dbffe5f2ce9457d2c891a8b99e3/)  to implement this changes.

## Things to consider
1. I don't know if "old config files" without the new three boolean attributes will lead to problems. Maybee the fixup method must be expanded for this reason?
2. The screenshot rules information is not configurable with the menu. I simply wouldn't know how to implement this. A corresponding disclaimer has been included to the config menu as a label with a text hint.
3. You could probably add the constant default values as settable within range?
4. Is the `Thread.Sleep` operation at line 687 in `ModEntry.cs` necessary; or could it also be made configurable to set `MILLISECONDS_TIMEOUT` "dynamically" to potentially avoid lag everytime a screenshot is taken?
5. The smapi nugget package you're using could be updated.

## Testing
I compiled and ran the game without any problems. The newly added features seemed to be working. Due to the fact that this is my first mod edit and pull request, I just wanna' stress that you may take a closer look.