### PR TITLE
Adjust constructor so two rules are not created when no config exists

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,3 +2,4 @@
 - Scott Atkins [@kins-dev]
 - f3wer [@f3wer]
 - Atravita Mods [@atravita-mods]
+- Daniel Vu [@dv297]

--- a/DailyScreenshot/ModConfig.cs
+++ b/DailyScreenshot/ModConfig.cs
@@ -82,10 +82,7 @@ namespace DailyScreenshot
         /// <summary>
         /// Rules loaded from the config file
         /// </summary>
-        public List<ModRule> SnapshotRules { get; set; } = new List<ModRule>
-        {
-            CreateDefaultSnapshotRule()
-        };
+        public List<ModRule> SnapshotRules { get; set; } = new List<ModRule>();
 
         /// <summary>
         /// Default settings for a set of rules in SnapshotRules
@@ -132,7 +129,7 @@ namespace DailyScreenshot
         public ModConfig()
         {
             m_launchGuid = Guid.NewGuid().ToString();
-            SnapshotRules.Add(new ModRule());
+            SnapshotRules.Add(CreateDefaultSnapshotRule());
             SnapshotRules[0].Name = m_launchGuid;
         }
 


### PR DESCRIPTION
The constructor was already creating a "default" rule. So between the field setter and the constructor, two unnamed rules were getting created when no config.json existed. 